### PR TITLE
fix: update hash without history entry

### DIFF
--- a/src/lib/app-model.tsx
+++ b/src/lib/app-model.tsx
@@ -76,7 +76,7 @@ export class AppModel {
             'state',
             JSONCrush(JSON.stringify({ files: this.files, selected: this.selected }))
         );
-        document.location.hash = searchParams.toString();
+        history.replaceState(undefined, window.name, '#' + searchParams.toString());
     }
     addFile = (fileName: string): void => {
         const filePath = getFilePathFromUserInput(fileName, this.fs.extname(fileName));


### PR DESCRIPTION
Currently when editing each character change create history entry for the browser 